### PR TITLE
Se corrige etiqueta latex para renderizar expresiones matemáticas.

### DIFF
--- a/content/posts/445.md
+++ b/content/posts/445.md
@@ -5,9 +5,11 @@ author_email: 'me@freddy.mx'
 date: Sun, 06 Oct 2013 22:48:35 +0000
 draft: false
 tags: ['Solution', 'Covarrubias', 'Etapa 1', 'Examen 14', 'macs', 'miguel', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
-**Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 14](https://omegaup.com/arena/IOI2014E1P14#problems/pista) **Autor:** Miguel Covarrubias **Fuente**: Codeforces
+- **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 14](https://omegaup.com/arena/IOI2014E1P14#problems/pista)
+- **Autor:** Miguel Covarrubias **Fuente**: Codeforces
 
 Este problema es una ligera modificación del Let's Play Osu! que apareció en la ronda 146 en Codeforces. [La solución explicada la pueden encontrar en el editorial.](http://codeforces.ru/blog/entry/5592)
 

--- a/content/posts/el-nuevo-ranking-de-omegaup.md
+++ b/content/posts/el-nuevo-ranking-de-omegaup.md
@@ -5,11 +5,18 @@ author_email: 'joemmanuel@gmail.com'
 date: Thu, 12 Jun 2014 14:42:18 +0000
 draft: false
 tags: ['Features', 'Ranking', 'Internals']
+math: true
 ---
 
 Con [este commit](https://github.com/omegaup/omegaup/commit/132e9c4614a7a4939156a942810559bf8c57f1a8) hemos introducido un cambio significativo en la forma de calcular el [ranking general](https://omegaup.com/rank.php) de omegaUp. Ahora no sólo es importante cuántos problemas ha resuelto un usuario sino que también estamos incluyendo la dificultad de cada uno de esos problemas. La dificultad es inversamente proporcional a la cantidad de soluciones completas (AC) que tiene ese problema.
 
-Para ser más precisos, estamos definiendo los puntos que da un problema así: $latex P\_i = \\frac{100}{log\_2(N+1)}$, donde $latex N$ representa la cantidad de ACs que tiene un problema. [Entre más ACs tenga un problema, menos puntos va a valer](http://fooplot.com/#W3sidHlwZSI6MCwiZXEiOiIxMDAvKGxvZyh4KzEpL2xvZygyKSkiLCJjb2xvciI6IiMwMDAwMDAifSx7InR5cGUiOjEwMDAsIndpbmRvdyI6WyItOC4xNTk5OTk5OTk5OTk5ODIiLCIxOTkuODQiLCItOC43OTk5OTk5OTk5OTk5OTciLCIxMTkuMTk5OTk5OTk5OTk5OTkiXX1d). Sólo estamos contando a lo más 1 AC por usuario para evitar que las soluciones de una misma persona afecten artificialmente los puntos de score del problema.
+Para ser más precisos, estamos definiendo los puntos que da un problema así: 
+
+$latex P\_i = \\frac{100}{log\_2(N+1)}$, 
+
+donde $latex N$ representa la cantidad de ACs que tiene un problema. 
+
+[Entre más ACs tenga un problema, menos puntos va a valer](http://fooplot.com/#W3sidHlwZSI6MCwiZXEiOiIxMDAvKGxvZyh4KzEpL2xvZygyKSkiLCJjb2xvciI6IiMwMDAwMDAifSx7InR5cGUiOjEwMDAsIndpbmRvdyI6WyItOC4xNTk5OTk5OTk5OTk5ODIiLCIxOTkuODQiLCItOC43OTk5OTk5OTk5OTk5OTciLCIxMTkuMTk5OTk5OTk5OTk5OTkiXX1d). Sólo estamos contando a lo más 1 AC por usuario para evitar que las soluciones de una misma persona afecten artificialmente los puntos de score del problema.
 
 [![](/images/Screen-Shot-2014-06-12-at-7.44.06-AM.png "Screen Shot 2014-06-12 at 7.44.06 AM")](/images/Screen-Shot-2014-06-12-at-7.44.06-AM.png)
 

--- a/content/posts/engranes-khayyam-solucion-enrique-lira.md
+++ b/content/posts/engranes-khayyam-solucion-enrique-lira.md
@@ -5,6 +5,7 @@ author_email: 'elira@elira.me'
 date: Sat, 13 Oct 2012 04:06:46 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 1', 'Khayyam', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2013, Etapa 1, Examen 1](https://omegaup.com/arena/IOI2013E1P1)**[ ](https://omegaup.com/arena/IOI2013E1P1) Autor: **[Omar Ocegueda (Khayyam)](http://www.linkedin.com/pub/jesus-omar-ocegueda-gonzalez/18/b45/5b9) **Solución por: **[Enrique Lira](http://elira.me/)

--- a/content/posts/introduccion-a-omegaup.md
+++ b/content/posts/introduccion-a-omegaup.md
@@ -5,6 +5,7 @@ author_email: 'joemmanuel@gmail.com'
 date: Wed, 09 Oct 2013 16:39:54 +0000
 draft: false
 tags: ['Documentation', 'Problemas', 'Introducción a omegaUp']
+math: true
 ---
 
 Estamos iniciando una serie de 10 posts para ayudar a nuestros nuevos usuarios a navegar con facilidad entre la gran cantidad de problemas de omegaUp, en forma de mini-tutoriales con los conceptos básicos, temas y fuentes. Esta colección de tutoriales y ligas te ayudarán a resolver muchos de los problemas de omegaUp y aumentar tu nivel de programación.

--- a/content/posts/invasion-zombie.md
+++ b/content/posts/invasion-zombie.md
@@ -5,6 +5,7 @@ author_email: 'rafaelrendonpablo@gmail.com'
 date: Thu, 12 Nov 2015 17:06:59 +0000
 draft: false
 tags: ['Solution', 'búsqueda binaria', 'geometría', 'Material de estudio']
+math: true
 ---
 
 Hola!, este es mi primer post en Omegaup y voy a describir mi solución para el problema [Invasion zombie](https://omegaup.com/arena/IOI2014E1P3/practice/#problems/invasionzombie). Hace un año encontré este problema, me pareció interesante y logre resolverlo, aunque algo tricky. Hace unos días me tope con este problema nuevamente y lo resolví por segunda ocasión, pero con una solución más simple, al menos eso creo.

--- a/content/posts/solucion-a-alfiles.md
+++ b/content/posts/solucion-a-alfiles.md
@@ -5,6 +5,7 @@ author_email: 'elira@elira.me'
 date: Mon, 07 Jan 2013 16:23:49 +0000
 draft: false
 tags: ['Solution', 'Alfiles', 'Etapa 1', 'Examen 7', 'Hugo Dueñas', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2013, Etapa 1, Examen 7](https://omegaup.com/arena/IOI2013E1P7) **Autor: **[Hugo Dueñas](mailto:hugochiquito.cpp@gmail.com)

--- a/content/posts/solucion-a-carretera.md
+++ b/content/posts/solucion-a-carretera.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Fri, 25 Jul 2014 04:28:19 +0000
 draft: false
 tags: ['Solution', '2014', 'carretera', 'Etapa 1', 'Examen 1', 'Freddy', 'nieves', 'preselectivo', 'solución', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2015, Etapa 1, Examen 1](https://omegaup.com/arena/IOI2015E1E1/#problems/carretera) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Edgar Augusto Santiago Nieves, [Freddy Román Cepeda](http://freddy.mx/)

--- a/content/posts/solucion-a-comesolo.md
+++ b/content/posts/solucion-a-comesolo.md
@@ -5,6 +5,7 @@ author_email: 'lhchavez@omegaup.com'
 date: Sat, 14 Sep 2013 05:21:32 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 5', 'felix', 'lhchavez', 'preselectivo', 'solución', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 8](https://omegaup.com/arena/problem/comesolo) **Autor:** [lhchavez](http://lhchavez.com) **Fuente**: Félix

--- a/content/posts/solucion-a-contrasena-binaria.md
+++ b/content/posts/solucion-a-contrasena-binaria.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Thu, 14 Aug 2014 16:06:31 +0000
 draft: false
 tags: ['Solution', '2014', 'binaria', 'contraseña', 'Etapa 1', 'preselectivo', 'Problemset 7', 'solución', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2015, Etapa 1, Problemset 7](https://omegaup.com/arena/IOI2015E1P7/#problems/contrasena-binaria) **Autor:** [Orlando Isay Mendoza Garcia](mailto:orlandoisay@gmail.com) **Fuente**: [Christian Adan Hernández Sánchez](mailto:chadancito@gmail.com)

--- a/content/posts/solucion-a-dp-generica.md
+++ b/content/posts/solucion-a-dp-generica.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Wed, 25 Sep 2013 06:00:06 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 13', 'Freddy', 'preselectivo', 'solución', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 13](https://omegaup.com/arena/IOI2014E1P13#problems/DP-Generica) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Project Euler

--- a/content/posts/solucion-a-la-venganza-de-silvio.md
+++ b/content/posts/solucion-a-la-venganza-de-silvio.md
@@ -5,6 +5,7 @@ author_email: 'elira@elira.me'
 date: Thu, 08 Aug 2013 02:02:51 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 1', 'Freddy', 'preselectivo', 'Silvio', 'solución', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 1](https://omegaup.com/arena/IOI2014E1P1#problems/VenganzaDeSilvio) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Freddy

--- a/content/posts/solucion-a-mario-reloaded.md
+++ b/content/posts/solucion-a-mario-reloaded.md
@@ -5,6 +5,7 @@ author_email: 'elira@elira.me'
 date: Mon, 07 Jan 2013 16:08:32 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 8', 'Pavel Herrera', 'preselectivo', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2013, Etapa 1, Examen 8](https://omegaup.com/arena/IOI2013E1P8) **Autor: **[Pavel Herrera Dominguez](mailto:paspartu@gmail.com))

--- a/content/posts/solucion-a-mocha-hojas.md
+++ b/content/posts/solucion-a-mocha-hojas.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Sat, 18 Jan 2014 23:25:14 +0000
 draft: false
 tags: ['Solution', 'beto', 'Etapa 1', 'Examen 17', 'Freddy', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 17](https://omegaup.com/arena/IOI2014E1P17#problems/Mocha-Hojas) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Alberto José Ramírez Valadez

--- a/content/posts/solucion-a-numeros-libres.md
+++ b/content/posts/solucion-a-numeros-libres.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Sat, 21 Jun 2014 23:24:56 +0000
 draft: false
 tags: ['Solution', 'Uncategorized']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2015, Etapa 1, Problemset 1](https://omegaup.com/arena/IOI2015E1P1#problems/Suma-Manhattan) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Edgar Augusto Santiago Nieves

--- a/content/posts/solucion-a-panoramas.md
+++ b/content/posts/solucion-a-panoramas.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Thu, 16 Jan 2014 17:36:38 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 17', 'macs', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 17](https://omegaup.com/arena/IOI2014E1P17#problems/Tour) **Autor:** Miguel Ángel Covarrubias **Fuente**: Miguel Ángel Covarrubias

--- a/content/posts/solucion-a-planetas.md
+++ b/content/posts/solucion-a-planetas.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Sun, 10 Aug 2014 05:16:54 +0000
 draft: false
 tags: ['Solution', 'Uncategorized']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2015, Etapa 1, Problemset 4](https://omegaup.com/arena/IOI2015E1P4#problems/Planetas) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Edgar Augusto Santiago Nieves

--- a/content/posts/solucion-a-poema-equino.md
+++ b/content/posts/solucion-a-poema-equino.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Sun, 27 Jul 2014 07:08:35 +0000
 draft: false
 tags: ['Solution', '2014', 'bfs', 'búsqueda', 'dfs', 'Etapa 1', 'Freddy', 'nieves', 'poema equino', 'preselectivo', 'Problemset 5', 'solución', 'soluciones', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2015, Etapa 1, Problemset 5](https://omegaup.com/arena/IOI2015E1P5/#problems/Poema-Equino) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Edgar Augusto Santiago Nieves, [Freddy Román Cepeda](http://freddy.mx/)

--- a/content/posts/solucion-a-problema.md
+++ b/content/posts/solucion-a-problema.md
@@ -5,6 +5,7 @@ author_email: 'elira@elira.me'
 date: Mon, 07 Jan 2013 16:34:20 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 10', 'Hugo Dueñas', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2013, Etapa 1, Examen 10](https://omegaup.com/arena/IOI2013E1P10) **Autor: **[Hugo Dueñas](mailto:hugochiquito.cpp@gmail.com)

--- a/content/posts/solucion-a-quimicos.md
+++ b/content/posts/solucion-a-quimicos.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Thu, 23 Jan 2014 03:51:39 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Ethan', 'Examen 6', 'lhchavez', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 6](https://omegaup.com/arena/IOI2014E1P6#problems/quimicos) **Autor:**  [Luis Héctor Chávez (lhchavez)](http://lhchavez.com/) **Fuente**: Ethan Jiménez Vargas

--- a/content/posts/solucion-a-suma-manhattan.md
+++ b/content/posts/solucion-a-suma-manhattan.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Sat, 21 Jun 2014 14:34:14 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'etapa 1', 'Freddy', 'manhattan', 'matemáticas', 'preselectivo', 'Problemset 1', 'problemset 1', 'soluciones', 'Soluciones Preselectivo 2014', 'sumas']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2015, Etapa 1, Problemset 1](https://omegaup.com/arena/IOI2015E1P1#problems/Suma-Manhattan) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: [Freddy Román Cepeda](http://freddy.mx/)

--- a/content/posts/solucion-a-ubongo-3d.md
+++ b/content/posts/solucion-a-ubongo-3d.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Sat, 14 Sep 2013 05:04:59 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Examen 8', 'macs', 'preselectivo', 'solución', 'Soluciones Preselectivo 2014']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 8](https://omegaup.com/arena/problem/ubongo-3d) **Autor:** Miguel Covarrubias **Fuente:** Miguel Covarrubias

--- a/content/posts/solucion-alternativa-a-decepcion.md
+++ b/content/posts/solucion-alternativa-a-decepcion.md
@@ -5,6 +5,7 @@ author_email: 'me@freddy.mx'
 date: Fri, 17 Jan 2014 02:14:47 +0000
 draft: false
 tags: ['Solution', 'Etapa 1', 'Ethan', 'Examen 8', 'Freddy', 'preselectivo', 'solución', 'Soluciones Preselectivo 2013']
+math: true
 ---
 
 **Concurso:** [Preselectivo para la IOI 2014, Etapa 1, Problemset 8](https://omegaup.com/arena/IOI2014E1P8#problems/decepcion) **Autor:** [Freddy Román Cepeda](http://freddy.mx/) **Fuente**: Ethan Jiménez Vargas


### PR DESCRIPTION
Se agrega etiqueta "math: true" en la definición del archivo markdown.

Para corregir los archivos donde se usan expresiones matemáticas.

En la liga: https://blog.omegaup.com/posts/el-nuevo-ranking-de-omegaup/ ya se corrige:
![image](https://github.com/user-attachments/assets/539bd667-fa82-45c1-9eab-ee15689fee36)
